### PR TITLE
Update calendar feed URL to use webcal scheme

### DIFF
--- a/file_helpers.py
+++ b/file_helpers.py
@@ -13,10 +13,13 @@ log = logging.getLogger(__name__)
 
 
 def feed_url(uid: int) -> str:
-    """
-    Return the public URL for a user's .ics feed.
-    """
-    return f"{BASE_URL}/cal/{uid}.ics"
+
+    # turn https://calendar.example.com into webcal://calendar.example.com
+    from urllib.parse import urlparse
+
+    parsed = urlparse(BASE_URL)
+    host = parsed.netloc
+    return f"webcal://{host}/cal/{uid}.ics"
 
 
 def idx_path(uid: int) -> Path:

--- a/server.py
+++ b/server.py
@@ -4,9 +4,11 @@ import aiohttp.web
 
 from config import HTTP_PORT, BASE_URL, POLL_INTERVAL
 from file_helpers import ics_path
+from urllib.parse import urlparse
 
 log = logging.getLogger(__name__)
 app = aiohttp.web.Application()
+parsed = urlparse(BASE_URL)
 
 
 async def handle_home(request: aiohttp.web.Request) -> aiohttp.web.Response:
@@ -37,8 +39,8 @@ async def handle_home(request: aiohttp.web.Request) -> aiohttp.web.Response:
     <p>Subscribe to your personal calendar feed and stay up-to-date automatically.</p>
     <p>Use the URL below, replacing <code>{'{id}'}</code> with your Discord ID:</p>
     <div class=\"input-group\">
-      <input type=\"text\" readonly value=\"{BASE_URL}/cal/{{YOUR_DISCORD_USER_ID}}.ics\" onclick=\"this.select(); document.execCommand('copy');\" />
-      <button onclick=\"navigator.clipboard.writeText('{BASE_URL}/cal/{{YOUR_DISCORD_USER_ID}}.ics');alert('Copied');\">Copy</button>
+     <input type="text" readonly value=f"webcal://{parsed.netloc}/cal/{{YOUR_DISCORD_USER_ID}}.ics"
+      <button onclick="navigator.clipboard.writeText(f'webcal://{parsed.netloc}/cal/{{YOUR_DISCORD_USER_ID}}.ics');alert('Copied');">
     </div>
     <div class=\"footer\">&copy; {dt.datetime.now().year} Bot. Auto-refresh every {POLL_INTERVAL} min.</div>
   </div>


### PR DESCRIPTION
- Add docstring to `feed_url` function in file_helpers.py
- Import `urlparse` in file_helpers.py
- Parse `BASE_URL` once and use it to construct webcal links
- Update homepage HTML to use parsed host for webcal link
- Improve user interaction for copying webcal link in server.py