### PR TITLE
Update calendar feed to use webcal scheme

### DIFF
--- a/file_helpers.py
+++ b/file_helpers.py
@@ -1,9 +1,10 @@
 # file_helpers.py
-
+# ----------------
 import json
 import logging
 from pathlib import Path
 from typing import List, Dict
+from urllib.parse import urlparse
 
 from ics import Calendar
 
@@ -13,10 +14,10 @@ log = logging.getLogger(__name__)
 
 
 def feed_url(uid: int) -> str:
-
-    # turn https://calendar.example.com into webcal://calendar.example.com
-    from urllib.parse import urlparse
-
+    """
+    Return the public URL for a user's .ics feed, using the webcal:// scheme.
+    """
+    # parse BASE_URL to extract host
     parsed = urlparse(BASE_URL)
     host = parsed.netloc
     return f"webcal://{host}/cal/{uid}.ics"

--- a/file_helpers.py
+++ b/file_helpers.py
@@ -13,10 +13,13 @@ log = logging.getLogger(__name__)
 
 
 def feed_url(uid: int) -> str:
-    """
-    Return the public URL for a user's .ics feed.
-    """
-    return f"{BASE_URL}/cal/{uid}.ics"
+
+    # turn https://calendar.example.com into webcal://calendar.example.com
+    from urllib.parse import urlparse
+
+    parsed = urlparse(BASE_URL)
+    host = parsed.netloc
+    return f"webcal://{host}/cal/{uid}.ics"
 
 
 def idx_path(uid: int) -> Path:

--- a/server.py
+++ b/server.py
@@ -4,9 +4,11 @@ import aiohttp.web
 
 from config import HTTP_PORT, BASE_URL, POLL_INTERVAL
 from file_helpers import ics_path
+from urllib.parse import urlparse
 
 log = logging.getLogger(__name__)
 app = aiohttp.web.Application()
+parsed = urlparse(BASE_URL)
 
 
 async def handle_home(request: aiohttp.web.Request) -> aiohttp.web.Response:
@@ -37,8 +39,8 @@ async def handle_home(request: aiohttp.web.Request) -> aiohttp.web.Response:
     <p>Subscribe to your personal calendar feed and stay up-to-date automatically.</p>
     <p>Use the URL below, replacing <code>{'{id}'}</code> with your Discord ID:</p>
     <div class=\"input-group\">
-      <input type=\"text\" readonly value=\"{BASE_URL}/cal/{{YOUR_DISCORD_USER_ID}}.ics\" onclick=\"this.select(); document.execCommand('copy');\" />
-      <button onclick=\"navigator.clipboard.writeText('{BASE_URL}/cal/{{YOUR_DISCORD_USER_ID}}.ics');alert('Copied');\">Copy</button>
+     <input type="text" readonly value=f"webcal://{parsed.netloc}/cal/{{YOUR_DISCORD_USER_ID}}.ics"
+      <button onclick="navigator.clipboard.writeText(f'webcal://{parsed.netloc}/cal/{{YOUR_DISCORD_USER_ID}}.ics');alert('Copied');">
     </div>
     <div class=\"footer\">&copy; {dt.datetime.now().year} Bot. Auto-refresh every {POLL_INTERVAL} min.</div>
   </div>

--- a/server.py
+++ b/server.py
@@ -1,18 +1,23 @@
+# server.py
+# ----------------
 import logging
 import datetime as dt
 import aiohttp.web
+from urllib.parse import urlparse
 
 from config import HTTP_PORT, BASE_URL, POLL_INTERVAL
 from file_helpers import ics_path
-from urllib.parse import urlparse
 
 log = logging.getLogger(__name__)
 app = aiohttp.web.Application()
+
+# parse HOST once for homepage webcal link
 parsed = urlparse(BASE_URL)
+host = parsed.netloc
 
 
 async def handle_home(request: aiohttp.web.Request) -> aiohttp.web.Response:
-    """Serve styled HTML homepage with subscription instructions."""
+    """Serve styled HTML homepage with subscription instructions, offering a webcal link."""
     html = f"""<!DOCTYPE html>
 <html lang=\"en\">
 <head>
@@ -39,8 +44,10 @@ async def handle_home(request: aiohttp.web.Request) -> aiohttp.web.Response:
     <p>Subscribe to your personal calendar feed and stay up-to-date automatically.</p>
     <p>Use the URL below, replacing <code>{'{id}'}</code> with your Discord ID:</p>
     <div class=\"input-group\">
-     <input type="text" readonly value=f"webcal://{parsed.netloc}/cal/{{YOUR_DISCORD_USER_ID}}.ics"
-      <button onclick="navigator.clipboard.writeText(f'webcal://{parsed.netloc}/cal/{{YOUR_DISCORD_USER_ID}}.ics');alert('Copied');">
+      <input type=\"text\" readonly
+             value=\"webcal://{host}/cal/{{YOUR_DISCORD_USER_ID}}.ics\"
+             onclick=\"this.select(); document.execCommand('copy');\" />
+      <button onclick=\"navigator.clipboard.writeText('webcal://{host}/cal/{{YOUR_DISCORD_USER_ID}}.ics');alert('Copied');\">Copy</button>
     </div>
     <div class=\"footer\">&copy; {dt.datetime.now().year} Bot. Auto-refresh every {POLL_INTERVAL} min.</div>
   </div>


### PR DESCRIPTION
Change the calendar feed URL to utilize the webcal scheme for better integration. Refactor URL handling to improve user experience when copying the webcal link.